### PR TITLE
Upgrade flutter_gemma to 0.13.0 with native systemInstruction

### DIFF
--- a/.claude/skills/upgrade-flutter-gemma/SKILL.md
+++ b/.claude/skills/upgrade-flutter-gemma/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: upgrade-flutter-gemma
+description: Upgrade flutter_gemma dependency — discover API changes, fix compilation, support new features, update tests, bump version
+---
+
+# Upgrade flutter_gemma dependency
+
+Follow these 5 phases sequentially. Do not skip phases. Ask the user before making decisions about new features (Phase 3).
+
+## Phase 1: Reconnaissance
+
+1. Run `dart pub outdated` to identify the available flutter_gemma version
+2. Update `flutter_gemma` version in both:
+   - `pubspec.yaml`
+   - `example/pubspec.yaml`
+3. Run `flutter pub get`
+4. Read the new version's CHANGELOG from pub cache:
+   ```
+   find ~/.pub-cache/hosted/pub.dev -maxdepth 1 -name "flutter_gemma-*" | sort
+   ```
+   Then read the CHANGELOG.md from the latest version directory.
+5. Summarize for the user:
+   - **Breaking changes** (removed/renamed APIs, changed signatures)
+   - **New APIs** (new parameters, methods, enums, classes)
+   - **Bug fixes**
+   - **Deprecations**
+
+## Phase 2: Fix Compilation
+
+1. Run `dart analyze`
+2. Fix all compilation errors. These typically appear in:
+
+   **Checklist of files that depend on flutter_gemma API:**
+   - [ ] `lib/src/flutter_gemma_runtime.dart` — `FlutterGemma.getActiveModel()`, `FlutterGemma.getActiveEmbedder()` signatures
+   - [ ] `lib/src/flutter_gemma_model.dart` — `InferenceModel.createChat()` signature, `ModelResponse` pattern matching, `InferenceChat` methods
+   - [ ] `lib/src/flutter_gemma_embedder.dart` — `EmbeddingModel.generateEmbeddings()` signature, `PreferredBackend` enum
+   - [ ] `lib/src/converters/request_converter.dart` — `Message` constructors (`.withImage`, `.withAudio`, `.toolCall`, `.toolResponse`)
+   - [ ] `lib/src/converters/response_converter.dart` — `ModelResponse` subtypes (`TextResponse`, `FunctionCallResponse`, `ParallelFunctionCallResponse`, `ThinkingResponse`)
+   - [ ] `lib/src/converters/tool_converter.dart` — `Tool` constructor
+   - [ ] `lib/src/flutter_gemma_plugin.dart` — `ModelType`, `ModelFileType` enums
+   - [ ] `test/src/fake_runtime.dart` — `FakeInferenceModel`, `FakeInferenceChat`, `FakeEmbeddingModel` must match upstream abstract class signatures
+
+3. Repeat `dart analyze` until clean (0 issues)
+
+## Phase 3: Support New Features
+
+Based on the CHANGELOG from Phase 1, decide with the user which new APIs to support.
+
+For each new feature, the typical integration points are:
+
+### New parameter in `createChat()` or `createSession()`
+1. Add field to `$FlutterGemmaModelOptions` in `lib/src/flutter_gemma_options.dart`
+2. **Manually** update `lib/src/flutter_gemma_options.g.dart`:
+   - Constructor parameter
+   - Field declaration with `@override`
+   - `fromJson` parsing
+   - `toJson` serialization
+   - `jsonSchema()` property entry
+3. Extract from config and pass in `lib/src/flutter_gemma_model.dart` (`_executeGeneration`)
+4. Update `FakeInferenceModel.createChat()` in `test/src/fake_runtime.dart` — add parameter, store in `last*` field for test assertions
+
+### New enum value (e.g. `ModelFileType`)
+1. Update comments in `lib/src/flutter_gemma_plugin.dart` (`FlutterGemmaModelConfig.fileType`)
+
+### New method on `InferenceChat` or `InferenceModel`
+1. Add override in `FakeInferenceChat` or `FakeInferenceModel` in `test/src/fake_runtime.dart`
+
+### Changed model capabilities
+1. Update `supports` map in `lib/src/flutter_gemma_plugin.dart` (`list()` method, ~line 123)
+
+### Changed message handling
+1. Update converters in `lib/src/converters/`
+2. Update `extractSystemInstruction()` if system message handling changed
+
+**IMPORTANT:** The `.g.dart` file is manually maintained (build_runner is broken). Always update it by hand when changing the schema.
+
+## Phase 4: Tests and Review
+
+1. **Update existing tests** that verify old behavior which has changed
+2. **Add new tests** for each new feature integrated in Phase 3
+3. Run `flutter test` — all tests must pass
+4. Run `/pr-review-toolkit:review-pr` for comprehensive review
+5. Fix any issues found by the review agents
+
+## Phase 5: Finalize
+
+1. **Bump version** in `pubspec.yaml`:
+   - Minor bump (e.g. `0.1.1` → `0.2.0`) if there are breaking behavioral changes
+   - Patch bump (e.g. `0.1.1` → `0.1.2`) if only bug fixes / non-breaking additions
+2. **Update `CHANGELOG.md`** — add new version section at the top with:
+   - Breaking changes (prefixed with `**Breaking**:`)
+   - New features
+   - Bug fixes
+3. **Update `README.md`**:
+   - Options table if new config fields were added
+   - Known Limitations section if capabilities changed
+   - Quick Start / examples if API usage changed
+4. **Verify everything:**
+   ```bash
+   dart analyze
+   flutter test
+   dart pub publish --dry-run
+   ```
+   All must pass cleanly.
+5. **Commit** on a feature branch (e.g. `feature/flutter-gemma-X.Y.Z`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.2.0
+
+- **Breaking**: Upgrade flutter_gemma dependency to ^0.13.0
+- **Breaking**: System messages are now passed natively via `createChat(systemInstruction:)` instead of being prepended to the first user message
+- Add `systemInstruction` config option for explicit system-level instructions
+- Support `ModelFileType.litertlm` for LiteRT-LM models (Gemma 4)
+- Advertise `systemRole: true` in Genkit model metadata
+- Throw on system-only requests (at least one user/model message required)
+- Throw on system messages with non-text content parts
+
 ## 0.1.1
 
 - Bump flutter_gemma dependency to ^0.12.8

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ final response = await ai.generate(
 | `isThinking` | `bool?` | false | Enable thinking mode |
 | `randomSeed` | `int?` | 1 | Random seed for deterministic output |
 | `toolChoice` | `String?` | `'auto'` | Tool calling mode: `'auto'`, `'required'`, `'none'` |
+| `systemInstruction` | `String?` | null | System-level instruction (overrides system-role messages) |
 
 ## Streaming
 
@@ -143,4 +144,4 @@ for (final embedding in embeddings) {
 ## Known Limitations
 
 - **Model installation**: The plugin does NOT manage model installation. The host app must install models via `FlutterGemma.installModel()` and embedders via `FlutterGemma.installEmbedder()` before using the plugin.
-- **System role**: flutter_gemma doesn't support a native system role. System messages are prepended to the first user message.
+- **System role**: System messages are passed natively via `createChat(systemInstruction:)` (requires flutter_gemma ^0.13.0). Only text content is supported in system messages.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_gemma: ^0.12.6
+  flutter_gemma: ^0.13.0
   genkit: ^0.12.0
   genkit_flutter_gemma:
     path: ../

--- a/lib/src/converters/request_converter.dart
+++ b/lib/src/converters/request_converter.dart
@@ -9,7 +9,11 @@ import 'file_reader.dart';
 
 /// Extracts and concatenates all system messages into a single string.
 ///
-/// Returns `null` if no system messages are present.
+/// Returns `null` if no system messages are present or all contain empty text.
+/// Throws if a system message has content parts but no extractable text
+/// (e.g. only media parts), since flutter_gemma only supports text system
+/// instructions.
+///
 /// Used to pass system instructions natively via `createChat(systemInstruction:)`.
 String? extractSystemInstruction(List<Message> messages) {
   final buffer = StringBuffer();
@@ -19,6 +23,12 @@ String? extractSystemInstruction(List<Message> messages) {
       if (text.isNotEmpty) {
         if (buffer.isNotEmpty) buffer.write('\n');
         buffer.write(text);
+      } else if (message.content.isNotEmpty) {
+        throw GenkitException(
+          'System message contains non-text parts which are not supported '
+          'for system instructions. Only text content is used.',
+          status: StatusCodes.INVALID_ARGUMENT,
+        );
       }
     }
   }

--- a/lib/src/converters/request_converter.dart
+++ b/lib/src/converters/request_converter.dart
@@ -7,10 +7,28 @@ import 'package:http/http.dart' as http;
 
 import 'file_reader.dart';
 
+/// Extracts and concatenates all system messages into a single string.
+///
+/// Returns `null` if no system messages are present.
+/// Used to pass system instructions natively via `createChat(systemInstruction:)`.
+String? extractSystemInstruction(List<Message> messages) {
+  final buffer = StringBuffer();
+  for (final message in messages) {
+    if (message.role == Role.system) {
+      final text = _extractText(message.content);
+      if (text.isNotEmpty) {
+        if (buffer.isNotEmpty) buffer.write('\n');
+        buffer.write(text);
+      }
+    }
+  }
+  return buffer.isEmpty ? null : buffer.toString();
+}
+
 /// Converts Genkit [ModelRequest] messages to flutter_gemma [gemma.Message] list.
 ///
 /// Key mapping rules:
-/// - `Role.system` → Prepended to first user message text (flutter_gemma has no system role)
+/// - `Role.system` → Skipped (handled via [extractSystemInstruction] + `createChat(systemInstruction:)`)
 /// - `Role.user` → `Message(text: ..., isUser: true, imageBytes: ..., audioBytes: ...)`
 /// - `Role.model` → `Message(text: ..., isUser: false)`
 /// - `Role.tool` → `Message.toolResponse(toolName: ..., response: ...)`
@@ -22,24 +40,15 @@ Future<List<gemma.Message>> convertMessages(
   http.Client? httpClient,
 }) async {
   final result = <gemma.Message>[];
-  String? pendingSystemText;
 
   for (final message in messages) {
     final role = message.role;
 
     if (role == Role.system) {
-      final text = _extractText(message.content);
-      if (text.isNotEmpty) {
-        pendingSystemText = (pendingSystemText != null)
-            ? '$pendingSystemText\n$text'
-            : text;
-      }
+      // System messages are handled natively via createChat(systemInstruction:).
+      continue;
     } else if (role == Role.user) {
-      var text = _extractText(message.content);
-      if (pendingSystemText != null) {
-        text = '$pendingSystemText\n\n$text';
-        pendingSystemText = null;
-      }
+      final text = _extractText(message.content);
       final imageBytes =
           await _extractMediaBytes(message.content, 'image', httpClient);
       final audioBytes =
@@ -81,11 +90,6 @@ Future<List<gemma.Message>> convertMessages(
         response: toolResponse.response,
       ));
     }
-  }
-
-  // If system text was never consumed (no user message followed), add as user.
-  if (pendingSystemText != null) {
-    result.add(gemma.Message(text: pendingSystemText, isUser: true));
   }
 
   return result;

--- a/lib/src/flutter_gemma_model.dart
+++ b/lib/src/flutter_gemma_model.dart
@@ -156,6 +156,13 @@ Future<ModelResponse> _executeGeneration({
 
   // Convert and add messages.
   final gemmaMessages = await convertMessages(request.messages);
+  if (gemmaMessages.isEmpty) {
+    throw GenkitException(
+      'No convertible messages in request. System messages alone are not '
+      'sufficient — at least one user or model message is required.',
+      status: StatusCodes.INVALID_ARGUMENT,
+    );
+  }
   for (final msg in gemmaMessages) {
     await chat.addQueryChunk(msg);
   }

--- a/lib/src/flutter_gemma_model.dart
+++ b/lib/src/flutter_gemma_model.dart
@@ -113,6 +113,8 @@ Future<ModelResponse> _executeGeneration({
     'none' => gemma.ToolChoice.none,
     _ => gemma.ToolChoice.auto,
   };
+  final systemInstruction = config?.systemInstruction ??
+      extractSystemInstruction(request.messages);
 
   // Get or create InferenceModel (cached if params match).
   final needsNewModel = cachedModel == null ||
@@ -149,6 +151,7 @@ Future<ModelResponse> _executeGeneration({
     isThinking: isThinking,
     modelType: modelType,
     toolChoice: gemmaToolChoice,
+    systemInstruction: systemInstruction,
   );
 
   // Convert and add messages.

--- a/lib/src/flutter_gemma_options.dart
+++ b/lib/src/flutter_gemma_options.dart
@@ -34,4 +34,8 @@ abstract class $FlutterGemmaModelOptions {
 
   /// Tool choice mode: 'auto', 'required', or 'none'. Defaults to 'auto'.
   String? get toolChoice;
+
+  /// System-level instruction passed natively to flutter_gemma's createChat().
+  /// If not set, system messages from the Genkit request are used instead.
+  String? get systemInstruction;
 }

--- a/lib/src/flutter_gemma_options.dart
+++ b/lib/src/flutter_gemma_options.dart
@@ -36,6 +36,7 @@ abstract class $FlutterGemmaModelOptions {
   String? get toolChoice;
 
   /// System-level instruction passed natively to flutter_gemma's createChat().
-  /// If not set, system messages from the Genkit request are used instead.
+  /// If set, takes priority over any system-role messages in the Genkit request.
+  /// If not set, system messages from the request are extracted and used instead.
   String? get systemInstruction;
 }

--- a/lib/src/flutter_gemma_options.g.dart
+++ b/lib/src/flutter_gemma_options.g.dart
@@ -17,6 +17,7 @@ class FlutterGemmaModelOptions implements $FlutterGemmaModelOptions {
     this.isThinking,
     this.randomSeed,
     this.toolChoice,
+    this.systemInstruction,
   });
 
   @override
@@ -37,6 +38,8 @@ class FlutterGemmaModelOptions implements $FlutterGemmaModelOptions {
   final int? randomSeed;
   @override
   final String? toolChoice;
+  @override
+  final String? systemInstruction;
 
   static final $schema = _FlutterGemmaModelOptionsSchema();
 
@@ -51,6 +54,7 @@ class FlutterGemmaModelOptions implements $FlutterGemmaModelOptions {
       isThinking: json['isThinking'] as bool?,
       randomSeed: json['randomSeed'] as int?,
       toolChoice: json['toolChoice'] as String?,
+      systemInstruction: json['systemInstruction'] as String?,
     );
   }
 
@@ -65,6 +69,7 @@ class FlutterGemmaModelOptions implements $FlutterGemmaModelOptions {
       if (isThinking != null) 'isThinking': isThinking,
       if (randomSeed != null) 'randomSeed': randomSeed,
       if (toolChoice != null) 'toolChoice': toolChoice,
+      if (systemInstruction != null) 'systemInstruction': systemInstruction,
     };
   }
 }
@@ -115,6 +120,12 @@ class _FlutterGemmaModelOptionsSchema {
           'description':
               "Tool choice mode: 'auto', 'required', or 'none'. Defaults to 'auto'.",
           'enum': ['auto', 'required', 'none'],
+        },
+        'systemInstruction': {
+          'type': 'string',
+          'description':
+              'System-level instruction passed natively to flutter_gemma. '
+              'If not set, system messages from the Genkit request are used.',
         },
       },
     };

--- a/lib/src/flutter_gemma_options.g.dart
+++ b/lib/src/flutter_gemma_options.g.dart
@@ -125,7 +125,8 @@ class _FlutterGemmaModelOptionsSchema {
           'type': 'string',
           'description':
               'System-level instruction passed natively to flutter_gemma. '
-              'If not set, system messages from the Genkit request are used.',
+              'If set, takes priority over system-role messages in the request. '
+              'If not set, system messages from the request are used.',
         },
       },
     };

--- a/lib/src/flutter_gemma_plugin.dart
+++ b/lib/src/flutter_gemma_plugin.dart
@@ -26,7 +26,7 @@ class FlutterGemmaModelConfig {
   /// The flutter_gemma model architecture type.
   final gemma.ModelType modelType;
 
-  /// The model file format (.task or .binary).
+  /// The model file format (.task, .binary, or .litertlm).
   final gemma.ModelFileType fileType;
 }
 
@@ -124,7 +124,7 @@ class GenkitFlutterGemmaPlugin extends GenkitPlugin {
               'multiturn': true,
               'media': true,
               'tools': true,
-              'systemRole': false,
+              'systemRole': true,
               'output': ['text'],
             },
           },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: genkit_flutter_gemma
 description: Genkit Dart plugin for flutter_gemma - local on-device AI inference via Google Gemma models.
-version: 0.1.1
+version: 0.2.0
 homepage: https://github.com/DenisovAV/genkit_flutter_gemma
 repository: https://github.com/DenisovAV/genkit_flutter_gemma
 issue_tracker: https://github.com/DenisovAV/genkit_flutter_gemma/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   flutter:
     sdk: flutter
   genkit: ^0.12.1
-  flutter_gemma: ^0.12.8
+  flutter_gemma: ^0.13.0
   http: ^1.2.0
   schemantic: ^0.1.1
 

--- a/test/converters/request_converter_test.dart
+++ b/test/converters/request_converter_test.dart
@@ -289,6 +289,23 @@ void main() {
     test('returns null for empty messages', () {
       expect(extractSystemInstruction([]), isNull);
     });
-  });
 
+    test('throws on system message with non-text parts only', () {
+      final messages = [
+        Message(role: Role.system, content: [
+          MediaPart(
+            media: Media(
+              url: 'data:image/png;base64,iVBOR',
+              contentType: 'image/png',
+            ),
+          ),
+        ]),
+      ];
+
+      expect(
+        () => extractSystemInstruction(messages),
+        throwsA(isA<GenkitException>()),
+      );
+    });
+  });
 }

--- a/test/converters/request_converter_test.dart
+++ b/test/converters/request_converter_test.dart
@@ -34,7 +34,8 @@ void main() {
       expect(result[0].isUser, isFalse);
     });
 
-    test('prepends system message to first user message', () async {
+    test('skips system messages (handled via extractSystemInstruction)',
+        () async {
       final messages = [
         Message(
           role: Role.system,
@@ -46,11 +47,11 @@ void main() {
       final result = await convertMessages(messages);
 
       expect(result, hasLength(1));
-      expect(result[0].text, 'You are helpful.\n\nHello');
+      expect(result[0].text, 'Hello');
       expect(result[0].isUser, isTrue);
     });
 
-    test('handles multiple system messages before user', () async {
+    test('skips multiple system messages', () async {
       final messages = [
         Message(role: Role.system, content: [TextPart(text: 'Rule 1')]),
         Message(role: Role.system, content: [TextPart(text: 'Rule 2')]),
@@ -60,11 +61,11 @@ void main() {
       final result = await convertMessages(messages);
 
       expect(result, hasLength(1));
-      expect(result[0].text, 'Rule 1\nRule 2\n\nHello');
+      expect(result[0].text, 'Hello');
       expect(result[0].isUser, isTrue);
     });
 
-    test('handles system-only messages (no user follows)', () async {
+    test('returns empty list for system-only messages', () async {
       final messages = [
         Message(
           role: Role.system,
@@ -74,9 +75,7 @@ void main() {
 
       final result = await convertMessages(messages);
 
-      expect(result, hasLength(1));
-      expect(result[0].text, 'System only');
-      expect(result[0].isUser, isTrue);
+      expect(result, isEmpty);
     });
 
     test('converts multi-turn conversation', () async {
@@ -255,4 +254,41 @@ void main() {
       expect(result[0].text, 'Part 1\nPart 2');
     });
   });
+
+  group('extractSystemInstruction', () {
+    test('extracts single system message', () {
+      final messages = [
+        Message(
+          role: Role.system,
+          content: [TextPart(text: 'You are helpful.')],
+        ),
+        Message(role: Role.user, content: [TextPart(text: 'Hello')]),
+      ];
+
+      expect(extractSystemInstruction(messages), 'You are helpful.');
+    });
+
+    test('concatenates multiple system messages', () {
+      final messages = [
+        Message(role: Role.system, content: [TextPart(text: 'Rule 1')]),
+        Message(role: Role.system, content: [TextPart(text: 'Rule 2')]),
+        Message(role: Role.user, content: [TextPart(text: 'Hello')]),
+      ];
+
+      expect(extractSystemInstruction(messages), 'Rule 1\nRule 2');
+    });
+
+    test('returns null when no system messages', () {
+      final messages = [
+        Message(role: Role.user, content: [TextPart(text: 'Hello')]),
+      ];
+
+      expect(extractSystemInstruction(messages), isNull);
+    });
+
+    test('returns null for empty messages', () {
+      expect(extractSystemInstruction([]), isNull);
+    });
+  });
+
 }

--- a/test/flutter_gemma_model_test.dart
+++ b/test/flutter_gemma_model_test.dart
@@ -390,5 +390,23 @@ void main() {
       expect(fakeChat.receivedMessages, hasLength(1));
       expect(fakeChat.receivedMessages[0].text, 'Hello');
     });
+
+    test('throws on system-only messages (no user or model messages)',
+        () async {
+      fakeChat.blockingResponse = const gemma.TextResponse('ok');
+      final model = buildModel();
+
+      await expectLater(
+        model(ModelRequest(
+          messages: [
+            Message(
+              role: Role.system,
+              content: [TextPart(text: 'Be helpful.')],
+            ),
+          ],
+        )),
+        throwsA(isA<GenkitException>()),
+      );
+    });
   });
 }

--- a/test/flutter_gemma_model_test.dart
+++ b/test/flutter_gemma_model_test.dart
@@ -321,5 +321,74 @@ void main() {
         throwsA(isA<GenkitException>()),
       );
     });
+
+    test('passes systemInstruction from config to createChat', () async {
+      fakeChat.blockingResponse = const gemma.TextResponse('ok');
+      final model = buildModel();
+
+      await model(ModelRequest(
+        messages: [
+          Message(role: Role.user, content: [TextPart(text: 'Hi')]),
+        ],
+        config: {'systemInstruction': 'Be concise.'},
+      ));
+
+      expect(fakeModel.lastSystemInstruction, 'Be concise.');
+    });
+
+    test('extracts systemInstruction from system messages', () async {
+      fakeChat.blockingResponse = const gemma.TextResponse('ok');
+      final model = buildModel();
+
+      await model(ModelRequest(
+        messages: [
+          Message(
+            role: Role.system,
+            content: [TextPart(text: 'You are helpful.')],
+          ),
+          Message(role: Role.user, content: [TextPart(text: 'Hi')]),
+        ],
+      ));
+
+      expect(fakeModel.lastSystemInstruction, 'You are helpful.');
+    });
+
+    test('config systemInstruction takes priority over system messages',
+        () async {
+      fakeChat.blockingResponse = const gemma.TextResponse('ok');
+      final model = buildModel();
+
+      await model(ModelRequest(
+        messages: [
+          Message(
+            role: Role.system,
+            content: [TextPart(text: 'From message.')],
+          ),
+          Message(role: Role.user, content: [TextPart(text: 'Hi')]),
+        ],
+        config: {'systemInstruction': 'From config.'},
+      ));
+
+      expect(fakeModel.lastSystemInstruction, 'From config.');
+    });
+
+    test('system messages are not prepended to user messages', () async {
+      fakeChat.blockingResponse = const gemma.TextResponse('ok');
+      final model = buildModel();
+
+      await model(ModelRequest(
+        messages: [
+          Message(
+            role: Role.system,
+            content: [TextPart(text: 'Be helpful.')],
+          ),
+          Message(role: Role.user, content: [TextPart(text: 'Hello')]),
+        ],
+      ));
+
+      // System message should be passed via createChat, not prepended to user message.
+      expect(fakeChat.receivedMessages, hasLength(1));
+      expect(fakeChat.receivedMessages[0].text, 'Hello');
+    });
   });
 }

--- a/test/flutter_gemma_plugin_test.dart
+++ b/test/flutter_gemma_plugin_test.dart
@@ -32,6 +32,10 @@ void main() {
       expect(metadata[0].name, 'flutter-gemma/gemma-3-nano');
       expect(metadata[0].actionType, 'model');
       expect(metadata[1].name, 'flutter-gemma/deepseek-r1');
+
+      final supports =
+          (metadata[0].metadata['model'] as Map)['supports'] as Map;
+      expect(supports['systemRole'], isTrue);
     });
 
     test('resolve() returns null for non-model action types', () {
@@ -162,6 +166,24 @@ void main() {
 
       expect(json['randomSeed'], 42);
       expect(json['toolChoice'], 'none');
+    });
+
+    test('fromJson parses systemInstruction', () {
+      final options = FlutterGemmaModelOptions.fromJson({
+        'systemInstruction': 'Be concise.',
+      });
+
+      expect(options.systemInstruction, 'Be concise.');
+    });
+
+    test('toJson includes systemInstruction when set, omits when null', () {
+      final withInstruction = FlutterGemmaModelOptions(
+        systemInstruction: 'Be helpful.',
+      );
+      final without = FlutterGemmaModelOptions();
+
+      expect(withInstruction.toJson()['systemInstruction'], 'Be helpful.');
+      expect(without.toJson().containsKey('systemInstruction'), isFalse);
     });
 
     test('schema provides JSON Schema', () {

--- a/test/src/fake_runtime.dart
+++ b/test/src/fake_runtime.dart
@@ -60,6 +60,7 @@ class FakeInferenceModel extends gemma.InferenceModel {
   gemma.InferenceChat? get chat => null;
 
   gemma.ToolChoice? lastToolChoice;
+  String? lastSystemInstruction;
 
   @override
   Future<gemma.InferenceChat> createChat({
@@ -76,9 +77,11 @@ class FakeInferenceModel extends gemma.InferenceModel {
     bool isThinking = false,
     gemma.ModelType? modelType,
     gemma.ToolChoice toolChoice = gemma.ToolChoice.auto,
+    String? systemInstruction,
   }) async {
     createChatCallCount++;
     lastToolChoice = toolChoice;
+    lastSystemInstruction = systemInstruction;
     return chatToReturn ?? FakeInferenceChat();
   }
 
@@ -91,6 +94,7 @@ class FakeInferenceModel extends gemma.InferenceModel {
     String? loraPath,
     bool? enableVisionModality,
     bool? enableAudioModality,
+    String? systemInstruction,
   }) async {
     throw UnimplementedError('FakeInferenceModel.createSession');
   }
@@ -144,6 +148,9 @@ class FakeInferenceChat extends gemma.InferenceChat {
       yield response;
     }
   }
+
+  @override
+  Future<void> close() async {}
 }
 
 /// Fake embedding model that returns preconfigured embeddings.


### PR DESCRIPTION
## Summary
- Upgrade flutter_gemma dependency from 0.12.8 to 0.13.0
- System messages now passed natively via `createChat(systemInstruction:)` instead of manual prepend to first user message
- Added `systemInstruction` config option with priority over system-role messages
- Support for `ModelFileType.litertlm` (Gemma 4 / LiteRT-LM models)
- Guards: throw on system-only requests and non-text system messages
- Advertise `systemRole: true` in Genkit model metadata
- Added `/upgrade-flutter-gemma` skill for future dependency upgrades

## Test plan
- [x] `dart analyze` — 0 issues
- [x] `flutter test` — 88 tests pass
- [x] `dart pub publish --dry-run` — clean
- [x] PR review via `/pr-review-toolkit:review-pr` — all issues addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)