### PR TITLE
Bump flutter_gemma to 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+- Bump flutter_gemma dependency to ^0.13.1 (LiteRT-LM 0.10.0, Gemma 4 thinking mode fix)
+
 ## 0.2.0
 
 - **Breaking**: Upgrade flutter_gemma dependency to ^0.13.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_gemma: ^0.13.0
+  flutter_gemma: ^0.13.1
   genkit: ^0.12.0
   genkit_flutter_gemma:
     path: ../

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: genkit_flutter_gemma
 description: Genkit Dart plugin for flutter_gemma - local on-device AI inference via Google Gemma models.
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/DenisovAV/genkit_flutter_gemma
 repository: https://github.com/DenisovAV/genkit_flutter_gemma
 issue_tracker: https://github.com/DenisovAV/genkit_flutter_gemma/issues
@@ -19,7 +19,7 @@ dependencies:
   flutter:
     sdk: flutter
   genkit: ^0.12.1
-  flutter_gemma: ^0.13.0
+  flutter_gemma: ^0.13.1
   http: ^1.2.0
   schemantic: ^0.1.1
 

--- a/test/src/fake_runtime.dart
+++ b/test/src/fake_runtime.dart
@@ -95,6 +95,7 @@ class FakeInferenceModel extends gemma.InferenceModel {
     bool? enableVisionModality,
     bool? enableAudioModality,
     String? systemInstruction,
+    bool enableThinking = false,
   }) async {
     throw UnimplementedError('FakeInferenceModel.createSession');
   }


### PR DESCRIPTION
## Summary
- Bump flutter_gemma from 0.13.0 to 0.13.1 (LiteRT-LM 0.10.0, Gemma 4 thinking fix)
- Update FakeInferenceModel.createSession for new enableThinking parameter
- Version 0.2.1

## Test plan
- [x] `dart analyze` — 0 issues
- [x] `flutter test` — 88 tests pass
- [x] `dart pub publish --dry-run` — clean