### PR TITLE
Bump genkit to ^0.13.0, schemantic to ^0.1.2

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_gemma: ^0.14.2
-  genkit: ^0.12.0
+  genkit: ^0.13.0
   genkit_flutter_gemma:
     path: ../
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,10 +18,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  genkit: ^0.12.1
+  genkit: ^0.13.0
   flutter_gemma: ^0.14.2
   http: ^1.2.0
-  schemantic: ^0.1.1
+  schemantic: ^0.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

- Bump `genkit` from `^0.12.1` to `^0.13.0`
- Bump `schemantic` from `^0.1.1` to `^0.1.2`

No API changes required — genkit 0.13.0 `GenerateTurnState` middleware change doesn't affect model/embedder implementations. schemantic 0.1.2 is a patch (additionalProperties support + analyzer compat).

## Test plan

- [x] `dart analyze` — 0 issues
- [x] `flutter test` — 90/90 passed