### PR TITLE
Bump flutter_gemma to 0.15.1, add enableSpeculativeDecoding option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1
+
+- Bump flutter_gemma dependency to ^0.15.1 (LiteRT-LM 0.11.0, MTP speculative decoding for Gemma 4, multi-image input, Android GPU fix, desktop storage path fix)
+- Add `enableSpeculativeDecoding` config option for Gemma 4 E2B/E4B MTP toggle (`null` = model default, `true`/`false` = force on/off)
+
 ## 0.3.0
 
 - Bump flutter_gemma dependency to ^0.14.2 (dart:ffi rewrite on desktop, ~5× faster cold start; fixes macOS `flutter test` install_name_tool failure)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ final response = await ai.generate(
 | `toolChoice` | `String?` | `'auto'` | Tool calling mode: `'auto'`, `'required'`, `'none'` |
 | `systemInstruction` | `String?` | null | System-level instruction (overrides system-role messages) |
 | `maxFunctionBufferLength` | `int?` | null | Max token buffer for streaming tool-call arguments (increase for large payloads) |
+| `enableSpeculativeDecoding` | `bool?` | null | MTP speculative decoding for Gemma 4 E2B/E4B (null = model default, true/false = force on/off) |
 
 ## Streaming
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_gemma: ^0.14.2
+  flutter_gemma: ^0.15.1
   genkit: ^0.13.0
   genkit_flutter_gemma:
     path: ../

--- a/lib/src/flutter_gemma_model.dart
+++ b/lib/src/flutter_gemma_model.dart
@@ -29,6 +29,7 @@ Model createFlutterGemmaModel({
   int? cachedMaxTokens;
   bool? cachedSupportImage;
   bool? cachedSupportAudio;
+  bool? cachedEnableSpeculativeDecoding;
 
   // Future-chain lock: each caller awaits the previous one, ensuring
   // only one generation runs at a time against the native model.
@@ -60,11 +61,13 @@ Model createFlutterGemmaModel({
           cachedMaxTokens: cachedMaxTokens,
           cachedSupportImage: cachedSupportImage,
           cachedSupportAudio: cachedSupportAudio,
-          onModelCached: (model, maxTokens, supportImage, supportAudio) {
+          cachedEnableSpeculativeDecoding: cachedEnableSpeculativeDecoding,
+          onModelCached: (model, maxTokens, supportImage, supportAudio, enableSpeculativeDecoding) {
             cachedModel = model;
             cachedMaxTokens = maxTokens;
             cachedSupportImage = supportImage;
             cachedSupportAudio = supportAudio;
+            cachedEnableSpeculativeDecoding = enableSpeculativeDecoding;
           },
         );
       } finally {
@@ -84,7 +87,8 @@ Future<ModelResponse> _executeGeneration({
   required int? cachedMaxTokens,
   required bool? cachedSupportImage,
   required bool? cachedSupportAudio,
-  required void Function(gemma.InferenceModel, int, bool, bool) onModelCached,
+  required bool? cachedEnableSpeculativeDecoding,
+  required void Function(gemma.InferenceModel, int, bool, bool, bool?) onModelCached,
 }) async {
   // Parse config from the untyped Map.
   final configMap = request.config;
@@ -108,6 +112,7 @@ Future<ModelResponse> _executeGeneration({
   final supportImage = config?.supportImage ?? false;
   final supportAudio = config?.supportAudio ?? false;
   final isThinking = config?.isThinking ?? false;
+  final enableSpeculativeDecoding = config?.enableSpeculativeDecoding;
   final gemmaToolChoice = switch (config?.toolChoice) {
     'required' => gemma.ToolChoice.required,
     'none' => gemma.ToolChoice.none,
@@ -121,7 +126,8 @@ Future<ModelResponse> _executeGeneration({
   final needsNewModel = cachedModel == null ||
       cachedMaxTokens != maxTokens ||
       cachedSupportImage != supportImage ||
-      cachedSupportAudio != supportAudio;
+      cachedSupportAudio != supportAudio ||
+      cachedEnableSpeculativeDecoding != enableSpeculativeDecoding;
 
   gemma.InferenceModel model;
   if (needsNewModel) {
@@ -129,8 +135,9 @@ Future<ModelResponse> _executeGeneration({
       maxTokens: maxTokens,
       supportImage: supportImage,
       supportAudio: supportAudio,
+      enableSpeculativeDecoding: enableSpeculativeDecoding,
     );
-    onModelCached(model, maxTokens, supportImage, supportAudio);
+    onModelCached(model, maxTokens, supportImage, supportAudio, enableSpeculativeDecoding);
   } else {
     model = cachedModel;
   }

--- a/lib/src/flutter_gemma_options.dart
+++ b/lib/src/flutter_gemma_options.dart
@@ -44,6 +44,11 @@ abstract class $FlutterGemmaModelOptions {
   /// arguments before parsing. Increase when models emit long function-call
   /// argument payloads. When null, flutter_gemma uses its built-in default.
   int? get maxFunctionBufferLength;
+
+  /// Multi-Token Prediction (speculative decoding) toggle for Gemma 4 E2B/E4B
+  /// (LiteRT-LM v0.11.0+). `null` honors the model's default; `true`/`false`
+  /// forces on/off. Ignored by models without an embedded MTP drafter.
+  bool? get enableSpeculativeDecoding;
 }
 
 /// Configuration options for flutter_gemma embedding generation.

--- a/lib/src/flutter_gemma_options.g.dart
+++ b/lib/src/flutter_gemma_options.g.dart
@@ -24,6 +24,7 @@ base class FlutterGemmaModelOptions {
     String? toolChoice,
     String? systemInstruction,
     int? maxFunctionBufferLength,
+    bool? enableSpeculativeDecoding,
   }) {
     _json = {
       'maxTokens': ?maxTokens,
@@ -37,6 +38,7 @@ base class FlutterGemmaModelOptions {
       'toolChoice': ?toolChoice,
       'systemInstruction': ?systemInstruction,
       'maxFunctionBufferLength': ?maxFunctionBufferLength,
+      'enableSpeculativeDecoding': ?enableSpeculativeDecoding,
     };
   }
 
@@ -177,6 +179,18 @@ base class FlutterGemmaModelOptions {
     }
   }
 
+  bool? get enableSpeculativeDecoding {
+    return _json['enableSpeculativeDecoding'] as bool?;
+  }
+
+  set enableSpeculativeDecoding(bool? value) {
+    if (value == null) {
+      _json.remove('enableSpeculativeDecoding');
+    } else {
+      _json['enableSpeculativeDecoding'] = value;
+    }
+  }
+
   @override
   String toString() {
     return _json.toString();
@@ -213,6 +227,7 @@ base class _FlutterGemmaModelOptionsTypeFactory
             'toolChoice': $Schema.string(),
             'systemInstruction': $Schema.string(),
             'maxFunctionBufferLength': $Schema.integer(),
+            'enableSpeculativeDecoding': $Schema.boolean(),
           },
           required: [],
           description: 'Configuration options for flutter_gemma inference',

--- a/lib/src/flutter_gemma_runtime.dart
+++ b/lib/src/flutter_gemma_runtime.dart
@@ -11,6 +11,7 @@ abstract class FlutterGemmaRuntime {
     int maxTokens = 1024,
     bool supportImage = false,
     bool supportAudio = false,
+    bool? enableSpeculativeDecoding,
   });
 
   /// Retrieves the active embedding model.
@@ -28,11 +29,13 @@ class DefaultFlutterGemmaRuntime implements FlutterGemmaRuntime {
     int maxTokens = 1024,
     bool supportImage = false,
     bool supportAudio = false,
+    bool? enableSpeculativeDecoding,
   }) {
     return gemma.FlutterGemma.getActiveModel(
       maxTokens: maxTokens,
       supportImage: supportImage,
       supportAudio: supportAudio,
+      enableSpeculativeDecoding: enableSpeculativeDecoding,
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: genkit_flutter_gemma
 description: Genkit Dart plugin for flutter_gemma - local on-device AI inference via Google Gemma models.
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/DenisovAV/genkit_flutter_gemma
 repository: https://github.com/DenisovAV/genkit_flutter_gemma
 issue_tracker: https://github.com/DenisovAV/genkit_flutter_gemma/issues
@@ -19,7 +19,7 @@ dependencies:
   flutter:
     sdk: flutter
   genkit: ^0.13.0
-  flutter_gemma: ^0.14.2
+  flutter_gemma: ^0.15.1
   http: ^1.2.0
   schemantic: ^0.1.2
 

--- a/test/flutter_gemma_model_test.dart
+++ b/test/flutter_gemma_model_test.dart
@@ -262,6 +262,21 @@ void main() {
       expect(runtime.getActiveModelCallCount, 2);
     });
 
+    test('recreates model when enableSpeculativeDecoding reverts to null',
+        () async {
+      fakeChat.blockingResponse = const gemma.TextResponse('ok');
+      final model = buildModel();
+
+      await model(ModelRequest(
+        messages: [Message(role: Role.user, content: [TextPart(text: 'Hi')])],
+        config: {'enableSpeculativeDecoding': true},
+      ));
+      await model(simpleRequest());
+
+      expect(runtime.getActiveModelCallCount, 2);
+      expect(runtime.lastEnableSpeculativeDecoding, isNull);
+    });
+
     test('blocking: returns parallel function call response', () async {
       fakeChat.blockingResponse = const gemma.ParallelFunctionCallResponse(
         calls: [

--- a/test/flutter_gemma_model_test.dart
+++ b/test/flutter_gemma_model_test.dart
@@ -227,6 +227,41 @@ void main() {
       expect(fakeModel.lastMaxFunctionBufferLength, isNull);
     });
 
+    test('passes enableSpeculativeDecoding to getActiveModel when set',
+        () async {
+      fakeChat.blockingResponse = const gemma.TextResponse('ok');
+      final model = buildModel();
+
+      await model(ModelRequest(
+        messages: [Message(role: Role.user, content: [TextPart(text: 'Hi')])],
+        config: {'enableSpeculativeDecoding': true},
+      ));
+
+      expect(runtime.lastEnableSpeculativeDecoding, isTrue);
+    });
+
+    test('passes null enableSpeculativeDecoding when not set', () async {
+      fakeChat.blockingResponse = const gemma.TextResponse('ok');
+      final model = buildModel();
+
+      await model(simpleRequest());
+
+      expect(runtime.lastEnableSpeculativeDecoding, isNull);
+    });
+
+    test('recreates model when enableSpeculativeDecoding changes', () async {
+      fakeChat.blockingResponse = const gemma.TextResponse('ok');
+      final model = buildModel();
+
+      await model(simpleRequest());
+      await model(ModelRequest(
+        messages: [Message(role: Role.user, content: [TextPart(text: 'Hi')])],
+        config: {'enableSpeculativeDecoding': false},
+      ));
+
+      expect(runtime.getActiveModelCallCount, 2);
+    });
+
     test('blocking: returns parallel function call response', () async {
       fakeChat.blockingResponse = const gemma.ParallelFunctionCallResponse(
         calls: [

--- a/test/src/fake_runtime.dart
+++ b/test/src/fake_runtime.dart
@@ -15,14 +15,18 @@ class FakeRuntime implements FlutterGemmaRuntime {
   int getActiveModelCallCount = 0;
   int getActiveEmbedderCallCount = 0;
 
+  bool? lastEnableSpeculativeDecoding;
+
   @override
   Future<gemma.InferenceModel> getActiveModel({
     int maxTokens = 1024,
     bool supportImage = false,
     bool supportAudio = false,
+    bool? enableSpeculativeDecoding,
   }) async {
     getActiveModelCallCount++;
     modelToReturn._maxTokens = maxTokens;
+    lastEnableSpeculativeDecoding = enableSpeculativeDecoding;
     return modelToReturn;
   }
 
@@ -137,7 +141,7 @@ class FakeInferenceChat extends gemma.InferenceChat {
   }
 
   @override
-  Future<void> addQueryChunk(gemma.Message message, [bool noTool = false]) async {
+  Future<void> addQueryChunk(gemma.Message message, [bool noTool = false, bool prefix = false]) async {
     addQueryChunkCallCount++;
     receivedMessages.add(message);
   }


### PR DESCRIPTION
## Summary

- Upgrades `flutter_gemma` dependency from `^0.14.2` to `^0.15.1` (LiteRT-LM 0.11.0)
- Adds `enableSpeculativeDecoding: bool?` config option for Gemma 4 MTP (Multi-Token Prediction / speculative decoding)
- Syncs `FakeInferenceChat.addQueryChunk` with new `prefix` parameter from 0.15.1

## flutter_gemma 0.15.x highlights

- **LiteRT-LM 0.11.0** — MTP-capable Gemma 4 + speculative decoding on macOS/iOS/Android/Windows
- **`enableSpeculativeDecoding`** flag on `getActiveModel()` (null = model default; true/false overrides)
- **Multi-image input** — `Message.withImages([...])` (backward-compat, old `withImage` still works)
- **Android GPU sampler dlopen fix** — companion `.so` patching
- **Desktop storage** — uses Application Support instead of Documents on macOS/Windows/Linux
- **Windows Intel NPU** end-to-end support
- **Web build fix** — `enableSpeculativeDecoding` stub was missing on web target in 0.15.0

## Changes

- `pubspec.yaml` / `example/pubspec.yaml`: `flutter_gemma: ^0.15.1`
- `lib/src/flutter_gemma_options.dart` + `.g.dart`: new `enableSpeculativeDecoding: bool?` field
- `lib/src/flutter_gemma_runtime.dart`: pass `enableSpeculativeDecoding` through runtime interface
- `lib/src/flutter_gemma_model.dart`: extract option from config, add to cache key, pass to `getActiveModel`
- `test/src/fake_runtime.dart`: add `prefix` param to `addQueryChunk`, track `lastEnableSpeculativeDecoding`
- 3 new tests for `enableSpeculativeDecoding` (passes through, null default, cache invalidation)

## Test plan

- [x] `dart analyze` — 0 issues
- [x] `flutter test` — 93/93 passing
- [x] `dart pub publish --dry-run` — package valid