### PR TITLE
Upgrade flutter_gemma to ^1.0.0, bump plugin to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.4.0
+
+- Bump flutter_gemma dependency to ^1.0.0 (modular package split: core + opt-in engine/backend packages)
+- No changes to the public Genkit plugin API — `getActiveModel`/`getActiveEmbedder` signatures are unchanged, so all existing model/embedder config options keep working
+- **App setup change**: flutter_gemma 1.0.0 makes inference engines and embedding backends opt-in. Consuming apps must now register them in `FlutterGemma.initialize()` and add the relevant packages (`flutter_gemma_litertlm`, `flutter_gemma_mediapipe`, `flutter_gemma_embeddings`). See the updated example and README.
+- Update example app to register `LiteRtLmEngine`, `MediaPipeEngine`, and `LiteRtEmbeddingBackend`
+- Drop the removed iOS-specific embedding tokenizer path (`iosPath`) — flutter_gemma 0.15.2+ unified embedding on a single LiteRT C API path
+
 ## 0.3.1
 
 - Bump flutter_gemma dependency to ^0.15.1 (LiteRT-LM 0.11.0, MTP speculative decoding for Gemma 4, multi-image input, Android GPU fix, desktop storage path fix)

--- a/README.md
+++ b/README.md
@@ -29,15 +29,57 @@ Genkit Dart plugin for [flutter_gemma](https://pub.dev/packages/flutter_gemma) �
 | Phi | `ModelType.phi` | Phi-4 |
 | FunctionGemma | `ModelType.functionGemma` | Specialized function calling |
 
+## Setup
+
+`genkit_flutter_gemma` depends only on the **core** `flutter_gemma` package — it
+stays engine-agnostic. As of flutter_gemma 1.0.0 the inference engines and
+embedding backends ship as **separate, opt-in packages**, and the core
+registers none of them by default. Your app must add the packages it needs and
+register their providers in `FlutterGemma.initialize()`.
+
+| Package | Provider | Add it when you use… |
+|---|---|---|
+| `flutter_gemma_litertlm` | `LiteRtLmEngine()` | `.litertlm` models (Gemma 4, desktop) |
+| `flutter_gemma_mediapipe` | `MediaPipeEngine()` | `.task` / `.bin` models (Gemma 3, mobile/web) |
+| `flutter_gemma_embeddings` | `LiteRtEmbeddingBackend()` | text embeddings (EmbeddingGemma) |
+
+```yaml
+# pubspec.yaml (your app)
+dependencies:
+  genkit_flutter_gemma: ^0.4.0
+  flutter_gemma: ^1.0.0
+  flutter_gemma_litertlm: ^1.0.0   # only the engines/backends you actually use
+  flutter_gemma_mediapipe: ^1.0.0
+  flutter_gemma_embeddings: ^1.0.0
+```
+
+```dart
+// main() — register the providers from the packages you added above.
+await FlutterGemma.initialize(
+  inferenceEngines: const [LiteRtLmEngine(), MediaPipeEngine()],
+  embeddingBackends: const [LiteRtEmbeddingBackend()],
+);
+```
+
+> If you skip registration, the first `installModel` / `getActiveModel` throws a
+> `StateError` telling you to add the engine package.
+
 ## Quick Start
 
 ```dart
 import 'package:flutter_gemma/flutter_gemma.dart';
+// Engines/backends are opt-in (see Setup) — register the ones you need.
+import 'package:flutter_gemma_embeddings/flutter_gemma_embeddings.dart';
+import 'package:flutter_gemma_litertlm/flutter_gemma_litertlm.dart';
+import 'package:flutter_gemma_mediapipe/flutter_gemma_mediapipe.dart';
 import 'package:genkit/genkit.dart';
 import 'package:genkit_flutter_gemma/genkit_flutter_gemma.dart';
 
 // Initialize and install model (host app responsibility)
-await FlutterGemma.initialize();
+await FlutterGemma.initialize(
+  inferenceEngines: const [LiteRtLmEngine(), MediaPipeEngine()],
+  embeddingBackends: const [LiteRtEmbeddingBackend()],
+);
 await FlutterGemma.installModel(modelType: ModelType.gemmaIt)
     .fromAsset('assets/gemma-3-1b-it-int4.task')
     .install();
@@ -146,6 +188,7 @@ for (final embedding in embeddings) {
 
 ## Known Limitations
 
+- **Engine registration**: With flutter_gemma 1.0.0+ the inference engines and embedding backends are opt-in. The host app must add the relevant packages (`flutter_gemma_litertlm` for `.litertlm`, `flutter_gemma_mediapipe` for `.task`/`.bin`, `flutter_gemma_embeddings` for embeddings) and register their providers in `FlutterGemma.initialize()` before using the plugin.
 - **Model installation**: The plugin does NOT manage model installation. The host app must install models via `FlutterGemma.installModel()` and embedders via `FlutterGemma.installEmbedder()` before using the plugin.
 - **System role**: System messages are passed natively via `createChat(systemInstruction:)` (requires flutter_gemma ^0.13.0). Only text content is supported in system messages.
 - **Thinking mode**: Requires `.litertlm` model format. Supported on Android, iOS, and Desktop. Not supported on Web.

--- a/example/integration_test/caching_test.dart
+++ b/example/integration_test/caching_test.dart
@@ -3,7 +3,6 @@
 // Integration test: model lifecycle and caching through Genkit API.
 // Run: flutter test integration_test/caching_test.dart -d <device>
 
-import 'package:flutter_gemma/flutter_gemma.dart' hide Message;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:genkit/genkit.dart';
 import 'package:genkit_flutter_gemma/genkit_flutter_gemma.dart';
@@ -16,7 +15,7 @@ void main() {
   late Genkit ai;
 
   testWidgets('Caching: setUpAll — install model', (tester) async {
-    await FlutterGemma.initialize();
+    await initializeGemmaForTest();
     await ensureModelInstalled();
     ai = createTestGenkit();
   }, timeout: const Timeout(kInstallTimeout));

--- a/example/integration_test/direct_action_test.dart
+++ b/example/integration_test/direct_action_test.dart
@@ -16,7 +16,7 @@ void main() {
   late GenkitFlutterGemmaPlugin plugin;
 
   testWidgets('DirectAction: setUpAll — install model', (tester) async {
-    await FlutterGemma.initialize();
+    await initializeGemmaForTest();
     await ensureModelInstalled();
 
     plugin = GenkitFlutterGemmaPlugin(models: [

--- a/example/integration_test/embedder_test.dart
+++ b/example/integration_test/embedder_test.dart
@@ -6,7 +6,6 @@
 // Requires embedding model assets in example/assets/models/:
 // - embeddinggemma-300M_seq256_mixed-precision.tflite
 // - sentencepiece.model
-// - embeddinggemma_tokenizer.json (iOS)
 
 import 'dart:math' as math;
 
@@ -37,14 +36,13 @@ void main() {
   }
 
   testWidgets('Embedder: setUpAll — install model + embedder', (tester) async {
-    await FlutterGemma.initialize();
+    await initializeGemmaForTest();
     await ensureModelInstalled();
 
     await FlutterGemma.installEmbedder()
         .modelFromAsset(
             'assets/models/embeddinggemma-300M_seq256_mixed-precision.tflite')
-        .tokenizerFromAsset('assets/models/sentencepiece.model',
-            iosPath: 'assets/models/embeddinggemma_tokenizer.json')
+        .tokenizerFromAsset('assets/models/sentencepiece.model')
         .install();
 
     ai = createTestGenkitWithEmbedder();

--- a/example/integration_test/function_calling_test.dart
+++ b/example/integration_test/function_calling_test.dart
@@ -7,7 +7,6 @@
 // unstable with a model this small. Tests verify the pipeline doesn't crash
 // and responses have valid structure.
 
-import 'package:flutter_gemma/flutter_gemma.dart' hide Tool, Message;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:genkit/genkit.dart';
 import 'package:genkit_flutter_gemma/genkit_flutter_gemma.dart';
@@ -21,7 +20,7 @@ void main() {
   late Tool<Map<String, dynamic>, String> weatherTool;
 
   testWidgets('FunctionCalling: setUpAll — install model', (tester) async {
-    await FlutterGemma.initialize();
+    await initializeGemmaForTest();
     await ensureModelInstalled();
     ai = createTestGenkit();
 

--- a/example/integration_test/generation_test.dart
+++ b/example/integration_test/generation_test.dart
@@ -3,7 +3,6 @@
 // Integration test: generation scenarios through Genkit API.
 // Run: flutter test integration_test/generation_test.dart -d <device>
 
-import 'package:flutter_gemma/flutter_gemma.dart' hide Message;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:genkit/genkit.dart';
 import 'package:genkit_flutter_gemma/genkit_flutter_gemma.dart';
@@ -16,7 +15,7 @@ void main() {
   late Genkit ai;
 
   testWidgets('Generation: setUpAll — install model', (tester) async {
-    await FlutterGemma.initialize();
+    await initializeGemmaForTest();
     await ensureModelInstalled();
     ai = createTestGenkit();
   }, timeout: const Timeout(kInstallTimeout));

--- a/example/integration_test/smoke_test.dart
+++ b/example/integration_test/smoke_test.dart
@@ -3,7 +3,6 @@
 // Integration test: basic smoke test for genkit_flutter_gemma.
 // Run: flutter test integration_test/smoke_test.dart -d <device>
 
-import 'package:flutter_gemma/flutter_gemma.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:genkit_flutter_gemma/genkit_flutter_gemma.dart';
 
@@ -13,7 +12,7 @@ void main() {
   initIntegrationTest();
 
   testWidgets('Smoke: generate via Genkit API', (tester) async {
-    await FlutterGemma.initialize();
+    await initializeGemmaForTest();
     await ensureModelInstalled();
 
     final ai = createTestGenkit();

--- a/example/integration_test/test_helpers.dart
+++ b/example/integration_test/test_helpers.dart
@@ -5,6 +5,9 @@ import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart' show kIsWeb, debugPrint;
 import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma_embeddings/flutter_gemma_embeddings.dart';
+import 'package:flutter_gemma_litertlm/flutter_gemma_litertlm.dart';
+import 'package:flutter_gemma_mediapipe/flutter_gemma_mediapipe.dart';
 import 'package:genkit/genkit.dart';
 import 'package:genkit_flutter_gemma/genkit_flutter_gemma.dart';
 import 'package:integration_test/integration_test.dart';
@@ -12,6 +15,18 @@ import 'package:integration_test/integration_test.dart';
 /// Call once in main() of each test file.
 void initIntegrationTest() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+}
+
+/// Initialize flutter_gemma with the opt-in engines/backends the tests need.
+///
+/// flutter_gemma 1.0.0 split engines and embedding backends into separate
+/// packages; core registers none by default, so tests must register the
+/// providers explicitly before installing or running any model.
+Future<void> initializeGemmaForTest() async {
+  await FlutterGemma.initialize(
+    inferenceEngines: const [LiteRtLmEngine(), MediaPipeEngine()],
+    embeddingBackends: const [LiteRtEmbeddingBackend()],
+  );
 }
 
 /// Model URLs for FunctionGemma 270M IT (284MB, no auth required).

--- a/example/lib/app_state.dart
+++ b/example/lib/app_state.dart
@@ -1,5 +1,4 @@
 import 'dart:developer' as developer;
-import 'dart:io' show Platform;
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
@@ -54,8 +53,6 @@ class AppState extends ChangeNotifier {
       'https://huggingface.co/litert-community/embeddinggemma-300m/resolve/main/embeddinggemma-300M_seq256_mixed-precision.tflite';
   String embedderTokenizerUrl =
       'https://huggingface.co/litert-community/embeddinggemma-300m/resolve/main/sentencepiece.model';
-  String embedderIosTokenizerUrl =
-      'https://github.com/DenisovAV/flutter_gemma/releases/download/v0.12.5/embeddinggemma_tokenizer.json';
 
   int _maxTokens = 1024;
   int get maxTokens => _maxTokens;
@@ -189,18 +186,13 @@ class AppState extends ChangeNotifier {
         token: hfToken.isNotEmpty ? hfToken : null,
       );
 
-      final withTokenizer = (!kIsWeb &&
-              Platform.isIOS &&
-              embedderIosTokenizerUrl.isNotEmpty)
-          ? installer.tokenizerFromNetwork(
-              embedderTokenizerUrl,
-              token: hfToken.isNotEmpty ? hfToken : null,
-              iosPath: embedderIosTokenizerUrl,
-            )
-          : installer.tokenizerFromNetwork(
-              embedderTokenizerUrl,
-              token: hfToken.isNotEmpty ? hfToken : null,
-            );
+      // flutter_gemma 0.15.2+ unified embedding on a single LiteRT C API path,
+      // so the per-platform iOS tokenizer (iosPath) was dropped — the same
+      // tokenizer source now works on every platform.
+      final withTokenizer = installer.tokenizerFromNetwork(
+        embedderTokenizerUrl,
+        token: hfToken.isNotEmpty ? hfToken : null,
+      );
 
       await withTokenizer.install();
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:flutter_gemma_embeddings/flutter_gemma_embeddings.dart';
+import 'package:flutter_gemma_litertlm/flutter_gemma_litertlm.dart';
+import 'package:flutter_gemma_mediapipe/flutter_gemma_mediapipe.dart';
 
 import 'app_state.dart';
 import 'screens/chat_screen.dart';
@@ -9,7 +12,14 @@ import 'screens/tools_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await FlutterGemma.initialize();
+  // flutter_gemma 1.0.0: engines and embedding backends are opt-in. Register
+  // the providers from the packages this example depends on — MediaPipe for
+  // .task/.bin models, LiteRT-LM for .litertlm models, and the LiteRT
+  // embedding backend for the embeddings demo.
+  await FlutterGemma.initialize(
+    inferenceEngines: const [LiteRtLmEngine(), MediaPipeEngine()],
+    embeddingBackends: const [LiteRtEmbeddingBackend()],
+  );
   runApp(const App());
 }
 

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,9 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import flutter_gemma
+import large_file_handler
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterGemmaPlugin.register(with: registry.registrar(forPlugin: "FlutterGemmaPlugin"))
+  LargeFileHandlerPlugin.register(with: registry.registrar(forPlugin: "LargeFileHandlerPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_gemma: ^0.15.1
+  flutter_gemma: ^1.0.0
+  # flutter_gemma 1.0.0 split engines/backends into opt-in packages; register
+  # them via FlutterGemma.initialize() in main.dart. The bridge package itself
+  # stays engine-agnostic — these deps live in the consuming app only.
+  flutter_gemma_litertlm: ^1.0.0
+  flutter_gemma_mediapipe: ^1.0.0
+  flutter_gemma_embeddings: ^1.0.0
   genkit: ^0.13.0
   genkit_flutter_gemma:
     path: ../

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: genkit_flutter_gemma
 description: Genkit Dart plugin for flutter_gemma - local on-device AI inference via Google Gemma models.
-version: 0.3.1
+version: 0.4.0
 homepage: https://github.com/DenisovAV/genkit_flutter_gemma
 repository: https://github.com/DenisovAV/genkit_flutter_gemma
 issue_tracker: https://github.com/DenisovAV/genkit_flutter_gemma/issues
@@ -19,7 +19,7 @@ dependencies:
   flutter:
     sdk: flutter
   genkit: ^0.13.0
-  flutter_gemma: ^0.15.1
+  flutter_gemma: ^1.0.0
   http: ^1.2.0
   schemantic: ^0.1.2
 

--- a/test/src/fake_runtime.dart
+++ b/test/src/fake_runtime.dart
@@ -55,6 +55,14 @@ class FakeInferenceModel extends gemma.InferenceModel {
   gemma.ModelFileType get fileType => gemma.ModelFileType.task;
 
   @override
+  gemma.PreferredBackend? get activeBackend => null;
+
+  @override
+  void addCloseListener(void Function() listener) {
+    // No-op: the fake holds no native handle to close.
+  }
+
+  @override
   gemma.InferenceModelSession? get session => null;
 
   @override
@@ -193,6 +201,11 @@ class FakeEmbeddingModel implements gemma.EmbeddingModel {
 
   @override
   Future<int> getDimension() async => 256;
+
+  @override
+  void addCloseListener(void Function() listener) {
+    // No-op: the fake holds no native handle to close.
+  }
 
   @override
   Future<void> close() async {}


### PR DESCRIPTION
## Summary

Upgrades the `flutter_gemma` dependency to `^1.0.0` and bumps the plugin to `0.4.0`.

flutter_gemma 1.0.0 is a **modular package split** (core + opt-in engine/backend packages). The Genkit plugin's public API is **unchanged** — `getActiveModel` / `getActiveEmbedder` signatures are identical, so all model/embedder config options keep working and **all 94 unit tests pass without modification**.

The bridge stays **engine-agnostic**: `genkit_flutter_gemma` depends only on core `flutter_gemma`. Choosing/registering engines is the consuming app's responsibility.

## Changes

- Bump `flutter_gemma` dependency `^0.15.1` → `^1.0.0`
- Add new `InferenceModel.activeBackend` / `addCloseListener` and `EmbeddingModel.addCloseListener` overrides to the test fakes (keep them in sync with upstream abstract signatures)
- **Example app**: register `LiteRtLmEngine`, `MediaPipeEngine`, and `LiteRtEmbeddingBackend` in `FlutterGemma.initialize()`; add the opt-in packages to `example/pubspec.yaml`; shared `initializeGemmaForTest()` helper for integration tests
- Drop the removed iOS-specific embedding tokenizer path (`iosPath`) — unified on a single LiteRT C API path since flutter_gemma 0.15.2
- **README**: new **Setup** section explaining the opt-in engine/backend packages (with a "which package when" table); document the registration requirement in Quick Start and Known Limitations
- **CHANGELOG**: 0.4.0 entry

## Verification

- `dart analyze` → No issues found
- `flutter test` → All 94 tests passed
- `dart pub publish --dry-run` → 0 warnings